### PR TITLE
Prevent crash when addic7ed does not respond

### DIFF
--- a/autosub/Addic7ed.py
+++ b/autosub/Addic7ed.py
@@ -585,6 +585,8 @@ class Addic7edAPI():
 
         show_ids={}
         html = self.get('/shows.php', login=False)
+        if not html:
+            return None
         show_ids = dict(url.split("\">") for url in re.findall(r'<a href=[\'"]/show/?([^<]+)', html))
 
         #----------------------------------------------------------------#


### PR DESCRIPTION
If en empty page is returned from the addic7ed show overview the the
regular expression findall will crash.
This change will prevent that.